### PR TITLE
Improve Node.JS's ECMAScript modules support

### DIFF
--- a/autoload/jsfileimport/utils.vim
+++ b/autoload/jsfileimport/utils.vim
@@ -46,7 +46,7 @@ function! jsfileimport#utils#_get_file_path(filepath) abort
 
   let l:path = a:filepath
 
-  if l:path =~? '\/index\(\.\(js\|jsx\|ts\|tsx\)\)\?$'
+  if g:js_file_import_strip_index_file && l:path =~? '\/index\(\.\(js\|jsx\|ts\|tsx\)\)\?$'
     let l:path = fnamemodify(l:path, ':h')
   endif
 

--- a/doc/vim-js-file-import.txt
+++ b/doc/vim-js-file-import.txt
@@ -358,6 +358,16 @@ g:js_file_import_strip_file_extension
 
 		Default value: `1`
 
+					      *g:js_file_import_strip_index_file*
+g:js_file_import_strip_index_file
+		Should remove `index.js` at the end of file path while importing.
+
+		Example of configuration compliant with Node.js `"type": "module"`:
+		`let g:js_file_import_strip_file_extension = 0`
+		`let g:js_file_import_strip_index_file = 0`
+
+		Default value: `1`
+
 ==============================================================================
 4. Functions					*vim-js-file-import-functions*
 

--- a/plugin/vim-js-file-import.vim
+++ b/plugin/vim-js-file-import.vim
@@ -19,6 +19,7 @@ let g:js_file_import_root_alias = get(g:, 'js_file_import_root_alias', '')
 let g:deoplete_strip_file_extension = get(g:, 'deoplete_strip_file_extension', 1)
 let g:js_file_import_string_quote = get(g:, 'js_file_import_string_quote', "'")
 let g:js_file_import_strip_file_extension = get(g:, 'js_file_import_strip_file_extension', 1)
+let g:js_file_import_strip_index_file = get(g:, 'js_file_import_strip_index_file', 1)
 let g:js_file_import_use_fzf = get(g:, 'js_file_import_use_fzf', 0)
 let g:js_file_import_use_telescope = get(g:, 'js_file_import_use_telescope', 0)
 


### PR DESCRIPTION
Based on [this](https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_mandatory_file_extensions) we need ability to disable `index` striping at the end of imported path.